### PR TITLE
Change getLogger name to be optional

### DIFF
--- a/logextractx/logger.py
+++ b/logextractx/logger.py
@@ -89,10 +89,10 @@ class LogExtraCtxAdapter(logging.LoggerAdapter):
         return msg, kwargs
 
 
-def getLogger(name: str, extra: Optional[dict] = None):
+def getLogger(name: str = None, extra: Optional[dict] = None):
     """
         returns logger adapted to extra context passing.
-        :param name:str - name of logger (just like in logging.getLogger()
+        :param name:str - optional string with name of logger (just like in logging.getLogger()
         :param extra:dict - optional dictionary with extra
     """
     extra = extra or {}

--- a/logextractx/test_logger.py
+++ b/logextractx/test_logger.py
@@ -53,3 +53,10 @@ def test_parent_propagate(log_capture):
     assert log_capture.records[-1].msg == "just msg"
     assert log_capture.records[-1].parent == "logger"
     assert log_capture.records[-1].child == "also logger"
+
+
+def test_get_logger_without_name(log_capture):
+    """ check if it is possible to get logger without providing name """
+    logger = logger_mod.getLogger()
+    logger.info("just msg")
+    assert log_capture.records[-1].msg == "just msg"


### PR DESCRIPTION
Issue: https://github.com/allegro/logextractx/issues/6
Now name getLogger is optional
Required test is present